### PR TITLE
refactor: Convert BaseEntity to abstract class and add TestEntity for Testing

### DIFF
--- a/src/main/java/xyz/sparta_project/manjok/global/common/dto/BaseEntity.java
+++ b/src/main/java/xyz/sparta_project/manjok/global/common/dto/BaseEntity.java
@@ -29,7 +29,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     /**
      * UUID 기반 ID (36자)

--- a/src/test/java/xyz/sparta_project/manjok/global/common/dto/BaseEntityTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/global/common/dto/BaseEntityTest.java
@@ -10,12 +10,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("BaseEntity")
 class BaseEntityTest {
+    
+    /**
+     * 테스트용 구체 클래스
+     * */
+    static class TestEntity extends BaseEntity {
+        // BaseENtity의 기능만 테스트하므로 추가 필드 불필요
+    }
 
     @Test
     @DisplayName("ID를 자동 생성한다.")
     void onCreate_generates_id() {
         //Given & When
-        BaseEntity entity = new BaseEntity();
+        TestEntity entity = new TestEntity();
 
         //Then
         assertThat(entity.getId()).isNotNull();
@@ -25,7 +32,7 @@ class BaseEntityTest {
     @DisplayName("생성된 ID는 36자다.")
     void generated_id_is_36_chars() {
         //Given & When
-        BaseEntity entity = new BaseEntity();
+        TestEntity entity = new TestEntity();
 
         //Then
         assertThat(entity.getId()).hasSize(36);
@@ -35,7 +42,7 @@ class BaseEntityTest {
     @DisplayName("생성된 ID는 유효한 UUID이다.")
     void generated_id_is_valid_uuid() {
         //Given & When
-        BaseEntity entity = new BaseEntity();
+        TestEntity entity = new TestEntity();
 
         //Then
         assertThat(UuidUtils.isValid(entity.getId())).isTrue();
@@ -45,7 +52,7 @@ class BaseEntityTest {
     @DisplayName("createdAt을 자동 설정한다.")
     void onCreate_sets_created_at() {
         //Given & When
-        BaseEntity entity = new BaseEntity();
+        TestEntity entity = new TestEntity();
 
         //Then
         assertThat(entity.getCreatedAt()).isNotNull();
@@ -56,7 +63,7 @@ class BaseEntityTest {
     void created_at_is_current_server_time() {
         //Given
         LocalDateTime before = LocalDateTime.now();
-        BaseEntity entity = new BaseEntity();
+        TestEntity entity = new TestEntity();
 
         //Then
         LocalDateTime after = LocalDateTime.now();
@@ -70,8 +77,8 @@ class BaseEntityTest {
     @DisplayName("매번 다른 ID를 생성한다.")
     void generates_unique_ids() {
         //Given & When
-        BaseEntity entity1 = new BaseEntity();
-        BaseEntity entity2 = new BaseEntity();
+        TestEntity entity1 = new TestEntity();
+        TestEntity entity2 = new TestEntity();
 
         //Then
         assertThat(entity1.getId()).isNotEqualTo(entity2.getId());
@@ -81,7 +88,7 @@ class BaseEntityTest {
     @DisplayName("이미 ID와 createdAt가 있으면 새로 생성하지 않는다.")
     void does_not_override_existing_id() {
         //Given & When
-        BaseEntity entity = new BaseEntity();
+        TestEntity entity = new TestEntity();
         String existingId = entity.getId();
         LocalDateTime existingCreatedAt = entity.getCreatedAt();
 
@@ -94,8 +101,8 @@ class BaseEntityTest {
     @DisplayName("같은 ID를 가진 엔티티는 같다.")
     void entities_with_same_id_are_equal() throws Exception {
         //Given & When
-        BaseEntity entity1 = new BaseEntity();
-        BaseEntity entity2 = new BaseEntity();
+        TestEntity entity1 = new TestEntity();
+        TestEntity entity2 = new TestEntity();
 
         var field = BaseEntity.class.getDeclaredField("id");
         field.setAccessible(true);
@@ -111,8 +118,8 @@ class BaseEntityTest {
     @DisplayName("다른 ID를 가진 엔티티는 다르다.")
     void entities_with_different_ids_are_not_equal() {
         //Given & When
-        BaseEntity entity1 = new BaseEntity();
-        BaseEntity entity2 = new BaseEntity();
+        TestEntity entity1 = new TestEntity();
+        TestEntity entity2 = new TestEntity();
 
         //When
         assertThat(entity1).isNotEqualTo(entity2);


### PR DESCRIPTION
1. 요약 (Summary)

BaseEntity를 일반 클래스에서 상속 전용 추상 클래스(@MappedSuperclass) 로 전환했습니다.

이를 검증하기 위해 빌트인 테스트 엔티티(TestEntity) 를 추가하여 상속 구조를 테스트했습니다.

2. 작업 내용 (Details)
   🔹 BaseEntity

abstract 키워드 추가 → 직접 인스턴스화 불가

@MappedSuperclass 적용 → 공통 필드(id, createdAt)가 하위 엔티티에 매핑되도록 개선

@NoArgsConstructor(access = PROTECTED) 적용 → 상속 엔티티에서만 생성 가능

equals, hashCode → ID 기반 동일성 판단 로직 유지

UuidUtils.generate()를 통한 UUID 자동 생성 유지

🔹 BaseEntityTest

내부에 테스트 전용 상속 클래스(TestEntity) 정의

직접 생성 대신 TestEntity 상속을 통해 BaseEntity의 자동 필드 초기화 동작 검증

UUID 유효성, ID 고유성, createdAt 자동 설정, equals/hashCode 일관성 테스트 포함

3. 변경 유형 (Change Type)

REFACTOR: 코드 구조 개선 및 추상화 전환

TEST: 상속 기반 단위 테스트 추가

4. 테스트 방법 (Testing)
   단위 테스트

BaseEntityTest 실행 시 모든 테스트 통과 확인

TestEntity 상속 구조에서 ID/createdAt 자동 생성 정상 확인

equals/hashCode 로직이 동일 ID 기준으로 일관성 있게 동작함 검증

주요 테스트 항목
테스트 항목	기대 결과
ID 자동 생성	UUID 36자 자동 생성
createdAt 자동 설정	현재 서버 시간 기준으로 설정
상속 구조 테스트	TestEntity 생성 시 필드 자동 주입 확인
equals/hashCode	동일 ID 기준으로 동등성 보장

. 기타 (Notes)

이번 변경으로 BaseEntity는 직접 생성 불가능한 상속 전용 기반 클래스가 되었습니다.

이후 모든 엔티티는 extends BaseEntity 형태로 ID와 createdAt을 자동 관리하게 됩니다.

테스트는 JPA 의존성 없이 순수 객체 단위에서 수행되었습니다
