### PR TITLE
feature/favorites

### DIFF
--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteCommandService.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteCommandService.java
@@ -1,0 +1,199 @@
+// FavoriteCommandService.java
+package xyz.sparta_project.manjok.domain.favorites.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteErrorCode;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.domain.repository.FavoriteRepository;
+import xyz.sparta_project.manjok.domain.restaurant.domain.event.WishlistChangedEvent;
+import xyz.sparta_project.manjok.global.infrastructure.event.infrastructure.Events;
+
+/**
+ * 찜하기 커맨드 서비스
+ * - 찜하기 생성, 삭제 등 쓰기 작업 처리
+ * - 찜하기 변경 시 이벤트 발행
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoriteCommandService {
+
+    private final FavoriteRepository favoriteRepository;
+
+    /**
+     * 레스토랑 찜하기 추가
+     */
+    public Favorite addRestaurantFavorite(String customerId, String restaurantId) {
+        log.info("레스토랑 찜하기 추가 시도 - CustomerId: {}, RestaurantId: {}", customerId, restaurantId);
+
+        // 중복 체크
+        if (favoriteRepository.existsByCustomerAndTarget(
+                customerId,
+                FavoriteType.RESTAURANT,
+                restaurantId,
+                null
+        )) {
+            log.warn("이미 찜한 레스토랑 - CustomerId: {}, RestaurantId: {}", customerId, restaurantId);
+            throw new FavoriteException(FavoriteErrorCode.ALREADY_FAVORITED);
+        }
+
+        try {
+            // 도메인 생성
+            Favorite favorite = Favorite.createRestaurantFavorite(
+                    customerId,
+                    restaurantId,
+                    customerId
+            );
+
+            // 저장
+            Favorite savedFavorite = favoriteRepository.save(favorite);
+
+            log.info("레스토랑 찜하기 추가 성공 - FavoriteId: {}, CustomerId: {}, RestaurantId: {}",
+                    savedFavorite.getId(), customerId, restaurantId);
+
+            // 이벤트 발행
+            publishWishlistAddedEvent(restaurantId, null);
+
+            return savedFavorite;
+
+        } catch (FavoriteException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("레스토랑 찜하기 추가 실패 - CustomerId: {}, RestaurantId: {}", customerId, restaurantId, e);
+            throw new FavoriteException(FavoriteErrorCode.FAVORITE_SAVE_FAILED, e);
+        }
+    }
+
+    /**
+     * 메뉴 찜하기 추가
+     */
+    public Favorite addMenuFavorite(String customerId, String restaurantId, String menuId) {
+        log.info("메뉴 찜하기 추가 시도 - CustomerId: {}, RestaurantId: {}, MenuId: {}",
+                customerId, restaurantId, menuId);
+
+        // 중복 체크
+        if (favoriteRepository.existsByCustomerAndTarget(
+                customerId,
+                FavoriteType.MENU,
+                restaurantId,
+                menuId
+        )) {
+            log.warn("이미 찜한 메뉴 - CustomerId: {}, RestaurantId: {}, MenuId: {}",
+                    customerId, restaurantId, menuId);
+            throw new FavoriteException(FavoriteErrorCode.ALREADY_FAVORITED);
+        }
+
+        try {
+            // 도메인 생성
+            Favorite favorite = Favorite.createMenuFavorite(
+                    customerId,
+                    restaurantId,
+                    menuId,
+                    customerId
+            );
+
+            // 저장
+            Favorite savedFavorite = favoriteRepository.save(favorite);
+
+            log.info("메뉴 찜하기 추가 성공 - FavoriteId: {}, CustomerId: {}, RestaurantId: {}, MenuId: {}",
+                    savedFavorite.getId(), customerId, restaurantId, menuId);
+
+            // 이벤트 발행
+            publishWishlistAddedEvent(restaurantId, menuId);
+
+            return savedFavorite;
+
+        } catch (FavoriteException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("메뉴 찜하기 추가 실패 - CustomerId: {}, RestaurantId: {}, MenuId: {}",
+                    customerId, restaurantId, menuId, e);
+            throw new FavoriteException(FavoriteErrorCode.FAVORITE_SAVE_FAILED, e);
+        }
+    }
+
+    /**
+     * 찜하기 취소 (하드 삭제)
+     */
+    public void removeFavorite(String customerId, String favoriteId) {
+        log.info("찜하기 삭제 시도 - CustomerId: {}, FavoriteId: {}", customerId, favoriteId);
+
+        // 찜하기 조회
+        Favorite favorite = favoriteRepository.findById(favoriteId)
+                .orElseThrow(() -> {
+                    log.warn("찜하기를 찾을 수 없음 - FavoriteId: {}", favoriteId);
+                    return new FavoriteException(FavoriteErrorCode.FAVORITE_NOT_FOUND);
+                });
+
+        // 본인 확인
+        favorite.validateOwner(customerId);
+
+        try {
+            // 삭제 전 정보 저장 (이벤트 발행용)
+            String restaurantId = favorite.getRestaurantId();
+            String menuId = favorite.getMenuId();
+
+            // 삭제
+            favoriteRepository.delete(favoriteId);
+
+            log.info("찜하기 삭제 성공 - FavoriteId: {}, CustomerId: {}", favoriteId, customerId);
+
+            // 이벤트 발행
+            publishWishlistRemovedEvent(restaurantId, menuId);
+
+        } catch (FavoriteException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("찜하기 삭제 실패 - FavoriteId: {}, CustomerId: {}", favoriteId, customerId, e);
+            throw new FavoriteException(FavoriteErrorCode.FAVORITE_DELETE_FAILED, e);
+        }
+    }
+
+    /**
+     * 찜하기 추가 이벤트 발행
+     */
+    private void publishWishlistAddedEvent(String restaurantId, String menuId) {
+        try {
+            WishlistChangedEvent event = new WishlistChangedEvent(
+                    restaurantId,
+                    menuId,
+                    WishlistChangedEvent.WishlistAction.ADDED
+            );
+
+            Events.raise(event);
+
+            log.info("찜하기 추가 이벤트 발행 완료 - RestaurantId: {}, MenuId: {}", restaurantId, menuId);
+
+        } catch (Exception e) {
+            log.error("찜하기 추가 이벤트 발행 실패 - RestaurantId: {}, MenuId: {}", restaurantId, menuId, e);
+            // 이벤트 발행 실패는 비즈니스 로직에 영향을 주지 않도록 예외를 던지지 않음
+        }
+    }
+
+    /**
+     * 찜하기 제거 이벤트 발행
+     */
+    private void publishWishlistRemovedEvent(String restaurantId, String menuId) {
+        try {
+            WishlistChangedEvent event = new WishlistChangedEvent(
+                    restaurantId,
+                    menuId,
+                    WishlistChangedEvent.WishlistAction.REMOVED
+            );
+
+            Events.raise(event);
+
+            log.info("찜하기 제거 이벤트 발행 완료 - RestaurantId: {}, MenuId: {}", restaurantId, menuId);
+
+        } catch (Exception e) {
+            log.error("찜하기 제거 이벤트 발행 실패 - RestaurantId: {}, MenuId: {}", restaurantId, menuId, e);
+            // 이벤트 발행 실패는 비즈니스 로직에 영향을 주지 않도록 예외를 던지지 않음
+        }
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteQueryService.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteQueryService.java
@@ -1,0 +1,186 @@
+// FavoriteQueryService.java
+package xyz.sparta_project.manjok.domain.favorites.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteErrorCode;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.domain.repository.FavoriteRepository;
+
+import java.util.List;
+
+/**
+ * 찜하기 쿼리 서비스
+ * - 찜하기 조회 등 읽기 작업 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteQueryService {
+
+    private final FavoriteRepository favoriteRepository;
+
+    /**
+     * 찜하기 상세 조회
+     */
+    public Favorite getFavorite(String favoriteId) {
+        log.debug("찜하기 조회 - FavoriteId: {}", favoriteId);
+
+        return favoriteRepository.findById(favoriteId)
+                .orElseThrow(() -> {
+                    log.warn("찜하기를 찾을 수 없음 - FavoriteId: {}", favoriteId);
+                    return new FavoriteException(FavoriteErrorCode.FAVORITE_NOT_FOUND);
+                });
+    }
+
+    /**
+     * 고객의 전체 찜하기 목록 조회
+     */
+    public List<Favorite> getCustomerFavorites(String customerId) {
+        log.debug("고객의 전체 찜하기 조회 - CustomerId: {}", customerId);
+
+        List<Favorite> favorites = favoriteRepository.findByCustomerId(customerId);
+
+        log.debug("고객의 찜하기 조회 완료 - CustomerId: {}, Count: {}", customerId, favorites.size());
+
+        return favorites;
+    }
+
+    /**
+     * 고객의 타입별 찜하기 목록 조회
+     */
+    public List<Favorite> getCustomerFavoritesByType(String customerId, FavoriteType type) {
+        log.debug("고객의 타입별 찜하기 조회 - CustomerId: {}, Type: {}", customerId, type);
+
+        List<Favorite> favorites = favoriteRepository.findByCustomerIdAndType(customerId, type);
+
+        log.debug("고객의 타입별 찜하기 조회 완료 - CustomerId: {}, Type: {}, Count: {}",
+                customerId, type, favorites.size());
+
+        return favorites;
+    }
+
+    /**
+     * 고객의 레스토랑 찜하기 목록 조회
+     */
+    public List<Favorite> getCustomerRestaurantFavorites(String customerId) {
+        log.debug("고객의 레스토랑 찜하기 조회 - CustomerId: {}", customerId);
+
+        return getCustomerFavoritesByType(customerId, FavoriteType.RESTAURANT);
+    }
+
+    /**
+     * 고객의 메뉴 찜하기 목록 조회
+     */
+    public List<Favorite> getCustomerMenuFavorites(String customerId) {
+        log.debug("고객의 메뉴 찜하기 조회 - CustomerId: {}", customerId);
+
+        return getCustomerFavoritesByType(customerId, FavoriteType.MENU);
+    }
+
+    /**
+     * 레스토랑의 찜하기 목록 조회
+     */
+    public List<Favorite> getRestaurantFavorites(String restaurantId) {
+        log.debug("레스토랑의 찜하기 조회 - RestaurantId: {}", restaurantId);
+
+        List<Favorite> favorites = favoriteRepository.findByRestaurantId(restaurantId);
+
+        log.debug("레스토랑의 찜하기 조회 완료 - RestaurantId: {}, Count: {}", restaurantId, favorites.size());
+
+        return favorites;
+    }
+
+    /**
+     * 찜하기 여부 확인
+     */
+    public boolean isFavorite(String customerId, FavoriteType type, String restaurantId, String menuId) {
+        log.debug("찜하기 여부 확인 - CustomerId: {}, Type: {}, RestaurantId: {}, MenuId: {}",
+                customerId, type, restaurantId, menuId);
+
+        return favoriteRepository.existsByCustomerAndTarget(customerId, type, restaurantId, menuId);
+    }
+
+    /**
+     * 레스토랑 찜하기 여부 확인
+     */
+    public boolean isRestaurantFavorite(String customerId, String restaurantId) {
+        log.debug("레스토랑 찜하기 여부 확인 - CustomerId: {}, RestaurantId: {}", customerId, restaurantId);
+
+        return favoriteRepository.existsByCustomerAndTarget(
+                customerId,
+                FavoriteType.RESTAURANT,
+                restaurantId,
+                null
+        );
+    }
+
+    /**
+     * 메뉴 찜하기 여부 확인
+     */
+    public boolean isMenuFavorite(String customerId, String restaurantId, String menuId) {
+        log.debug("메뉴 찜하기 여부 확인 - CustomerId: {}, RestaurantId: {}, MenuId: {}",
+                customerId, restaurantId, menuId);
+
+        return favoriteRepository.existsByCustomerAndTarget(
+                customerId,
+                FavoriteType.MENU,
+                restaurantId,
+                menuId
+        );
+    }
+
+    /**
+     * 고객의 찜하기 통계 조회
+     */
+    public FavoriteStatistics getCustomerFavoriteStatistics(String customerId) {
+        log.debug("고객의 찜하기 통계 조회 - CustomerId: {}", customerId);
+
+        long totalCount = favoriteRepository.countByCustomerId(customerId);
+        long restaurantCount = favoriteRepository.countByCustomerIdAndType(customerId, FavoriteType.RESTAURANT);
+        long menuCount = favoriteRepository.countByCustomerIdAndType(customerId, FavoriteType.MENU);
+
+        return new FavoriteStatistics(totalCount, restaurantCount, menuCount);
+    }
+
+    /**
+     * 레스토랑의 찜하기 통계 조회
+     */
+    public long getRestaurantFavoriteCount(String restaurantId) {
+        log.debug("레스토랑의 찜하기 개수 조회 - RestaurantId: {}", restaurantId);
+
+        return favoriteRepository.countByRestaurantId(restaurantId);
+    }
+
+    /**
+     * 찜하기 통계 내부 클래스
+     */
+    public static class FavoriteStatistics {
+        private final long totalCount;
+        private final long restaurantCount;
+        private final long menuCount;
+
+        public FavoriteStatistics(long totalCount, long restaurantCount, long menuCount) {
+            this.totalCount = totalCount;
+            this.restaurantCount = restaurantCount;
+            this.menuCount = menuCount;
+        }
+
+        public long getTotalCount() {
+            return totalCount;
+        }
+
+        public long getRestaurantCount() {
+            return restaurantCount;
+        }
+
+        public long getMenuCount() {
+            return menuCount;
+        }
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/exception/FavoriteErrorCode.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/exception/FavoriteErrorCode.java
@@ -1,0 +1,44 @@
+// FavoriteErrorCode.java
+package xyz.sparta_project.manjok.domain.favorites.domain.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import xyz.sparta_project.manjok.global.presentation.exception.ErrorCode;
+
+/**
+ * 찜하기 도메인 관련 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum FavoriteErrorCode implements ErrorCode {
+
+    // 생성 관련 (FAVORITE_001~009)
+    INVALID_CUSTOMER_ID("FAVORITE_001", "유효하지 않은 고객 ID입니다.", 400),
+    INVALID_FAVORITE_TYPE("FAVORITE_002", "유효하지 않은 찜하기 타입입니다.", 400),
+    INVALID_RESTAURANT_ID("FAVORITE_003", "유효하지 않은 레스토랑 ID입니다.", 400),
+    INVALID_MENU_ID("FAVORITE_004", "유효하지 않은 메뉴 ID입니다.", 400),
+    MENU_ID_REQUIRED("FAVORITE_005", "메뉴 타입인 경우 메뉴 ID는 필수입니다.", 400),
+    MENU_ID_NOT_ALLOWED("FAVORITE_006", "레스토랑 타입인 경우 메뉴 ID는 포함될 수 없습니다.", 400),
+
+    // 중복 관련 (FAVORITE_010~019)
+    ALREADY_FAVORITED("FAVORITE_010", "이미 찜한 항목입니다.", 409),
+    DUPLICATE_FAVORITE("FAVORITE_011", "중복된 찜하기입니다.", 409),
+
+    // 조회 관련 (FAVORITE_020~029)
+    FAVORITE_NOT_FOUND("FAVORITE_020", "찜하기를 찾을 수 없습니다.", 404),
+
+    // 권한 관련 (FAVORITE_030~039)
+    FORBIDDEN_FAVORITE_ACCESS("FAVORITE_030", "본인의 찜하기만 접근할 수 있습니다.", 403),
+    FORBIDDEN_FAVORITE_DELETE("FAVORITE_031", "본인의 찜하기만 삭제할 수 있습니다.", 403),
+
+    // 저장/삭제 관련 (FAVORITE_040~049)
+    FAVORITE_SAVE_FAILED("FAVORITE_040", "찜하기 저장에 실패했습니다.", 500),
+    FAVORITE_DELETE_FAILED("FAVORITE_041", "찜하기 삭제에 실패했습니다.", 500),
+
+    // 이벤트 처리 (FAVORITE_050~059)
+    EVENT_PROCESSING_FAILED("FAVORITE_050", "이벤트 처리 중 오류가 발생했습니다.", 500);
+
+    private final String code;
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/exception/FavoriteException.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/exception/FavoriteException.java
@@ -1,0 +1,39 @@
+package xyz.sparta_project.manjok.domain.favorites.domain.exception;
+
+import xyz.sparta_project.manjok.global.presentation.exception.ErrorCode;
+import xyz.sparta_project.manjok.global.presentation.exception.GlobalException;
+
+/**
+ * 찜하기 도메인 커스텀 예외
+ * GlobalException을 상속받아 일관된 예외 처리 구조 유지
+ */
+public class FavoriteException extends GlobalException {
+
+    /**
+     * ErrorCode만으로 예외 발생
+     */
+    public FavoriteException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    /**
+     * ErrorCode와 커스텀 메시지로 예외 생성
+     */
+    public FavoriteException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    /**
+     * ErrorCode와 원인 예외로 예외 처리
+     */
+    public FavoriteException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    /**
+     * ErrorCode, 커스텀 메시지, 원인 예외로 예외 생성
+     */
+    public FavoriteException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/model/Favorite.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/model/Favorite.java
@@ -1,0 +1,147 @@
+// Favorite.java
+package xyz.sparta_project.manjok.domain.favorites.domain.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteErrorCode;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+
+import java.time.LocalDateTime;
+
+/**
+ * 찜하기 Aggregate Root
+ * - 찜하기의 모든 정보와 비즈니스 규칙을 관리
+ * - 순수 도메인 모델
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Favorite {
+
+    // 식별자
+    private String id;
+    private LocalDateTime createdAt;
+
+    // 소유자 정보
+    private String customerId;
+
+    // 찜하기 타입
+    private FavoriteType type;
+
+    // 대상 정보
+    private String restaurantId;
+    private String menuId;
+
+    // 감사 필드
+    private String createdBy;
+    private LocalDateTime updatedAt;
+    private String updatedBy;
+
+    // ==================== 생성 ====================
+
+    /**
+     * 레스토랑 찜하기 생성
+     */
+    public static Favorite createRestaurantFavorite(String customerId, String restaurantId, String createdBy) {
+        Favorite favorite = Favorite.builder()
+                .customerId(customerId)
+                .type(FavoriteType.RESTAURANT)
+                .restaurantId(restaurantId)
+                .menuId(null)
+                .createdBy(createdBy)
+                .build();
+
+        favorite.validate();
+        return favorite;
+    }
+
+    /**
+     * 메뉴 찜하기 생성
+     */
+    public static Favorite createMenuFavorite(String customerId, String restaurantId, String menuId, String createdBy) {
+        Favorite favorite = Favorite.builder()
+                .customerId(customerId)
+                .type(FavoriteType.MENU)
+                .restaurantId(restaurantId)
+                .menuId(menuId)
+                .createdBy(createdBy)
+                .build();
+
+        favorite.validate();
+        return favorite;
+    }
+
+    // ==================== 비즈니스 메서드 ====================
+
+    /**
+     * 레스토랑 찜하기인지 확인
+     */
+    public boolean isRestaurantFavorite() {
+        return type == FavoriteType.RESTAURANT;
+    }
+
+    /**
+     * 메뉴 찜하기인지 확인
+     */
+    public boolean isMenuFavorite() {
+        return type == FavoriteType.MENU;
+    }
+
+    /**
+     * 동일한 찜하기인지 확인
+     */
+    public boolean isSameFavorite(Favorite other) {
+        if (this.type != other.type) return false;
+        if (!this.customerId.equals(other.customerId)) return false;
+        if (!this.restaurantId.equals(other.restaurantId)) return false;
+
+        if (this.type == FavoriteType.MENU) {
+            return this.menuId != null && this.menuId.equals(other.menuId);
+        }
+
+        return true;
+    }
+
+    /**
+     * 소유자 확인
+     */
+    public boolean isOwnedBy(String customerId) {
+        return this.customerId.equals(customerId);
+    }
+
+    /**
+     * 소유자 검증
+     */
+    public void validateOwner(String customerId) {
+        if (!isOwnedBy(customerId)) {
+            throw new FavoriteException(FavoriteErrorCode.FORBIDDEN_FAVORITE_ACCESS);
+        }
+    }
+
+    // ==================== 유틸리티 메서드 ====================
+
+    /**
+     * 검증
+     */
+    public void validate() {
+        if (customerId == null || customerId.trim().isEmpty()) {
+            throw new FavoriteException(FavoriteErrorCode.INVALID_CUSTOMER_ID);
+        }
+        if (type == null) {
+            throw new FavoriteException(FavoriteErrorCode.INVALID_FAVORITE_TYPE);
+        }
+        if (restaurantId == null || restaurantId.trim().isEmpty()) {
+            throw new FavoriteException(FavoriteErrorCode.INVALID_RESTAURANT_ID);
+        }
+        if (type == FavoriteType.MENU && (menuId == null || menuId.trim().isEmpty())) {
+            throw new FavoriteException(FavoriteErrorCode.MENU_ID_REQUIRED);
+        }
+        if (type == FavoriteType.RESTAURANT && menuId != null) {
+            throw new FavoriteException(FavoriteErrorCode.MENU_ID_NOT_ALLOWED);
+        }
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/model/FavoriteType.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/model/FavoriteType.java
@@ -1,0 +1,44 @@
+// FavoriteType.java
+package xyz.sparta_project.manjok.domain.favorites.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 찜하기 타입
+ */
+@Getter
+@RequiredArgsConstructor
+public enum FavoriteType {
+    RESTAURANT("레스토랑", "레스토랑 찜하기"),
+    MENU("메뉴", "메뉴 찜하기");
+
+    private final String displayName;
+    private final String description;
+
+    /**
+     * 문자열로부터 FavoriteType 찾기
+     */
+    public static FavoriteType fromString(String value) {
+        for (FavoriteType type : FavoriteType.values()) {
+            if (type.name().equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid FavoriteType: " + value);
+    }
+
+    /**
+     * 레스토랑 타입인지 확인
+     */
+    public boolean isRestaurant() {
+        return this == RESTAURANT;
+    }
+
+    /**
+     * 메뉴 타입인지 확인
+     */
+    public boolean isMenu() {
+        return this == MENU;
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/repository/FavoriteRepository.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/domain/repository/FavoriteRepository.java
@@ -1,0 +1,87 @@
+// FavoriteRepository.java
+package xyz.sparta_project.manjok.domain.favorites.domain.repository;
+
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 찜하기 도메인 리포지토리
+ * - 도메인 계층에서 필요한 저장소 기능 정의
+ */
+public interface FavoriteRepository {
+
+    // ==================== CREATE ====================
+
+    /**
+     * 찜하기 저장 (생성만 처리)
+     */
+    Favorite save(Favorite favorite);
+
+    // ==================== DELETE ====================
+
+    /**
+     * 찜하기 삭제 (하드 삭제)
+     */
+    void delete(String id);
+
+    // ==================== READ - 단건 조회 ====================
+
+    /**
+     * ID로 찜하기 조회
+     */
+    Optional<Favorite> findById(String id);
+
+    // ==================== READ - 목록 조회 ====================
+
+    /**
+     * 고객 ID로 찜하기 목록 조회
+     */
+    List<Favorite> findByCustomerId(String customerId);
+
+    /**
+     * 고객 ID와 타입으로 찜하기 목록 조회
+     */
+    List<Favorite> findByCustomerIdAndType(String customerId, FavoriteType type);
+
+    /**
+     * 레스토랑 ID로 찜하기 목록 조회
+     */
+    List<Favorite> findByRestaurantId(String restaurantId);
+
+    // ==================== 존재 확인 ====================
+
+    /**
+     * ID로 찜하기 존재 여부 확인
+     */
+    boolean existsById(String id);
+
+    /**
+     * 고객과 대상으로 찜하기 존재 여부 확인
+     */
+    boolean existsByCustomerAndTarget(
+            String customerId,
+            FavoriteType type,
+            String restaurantId,
+            String menuId
+    );
+
+    // ==================== 통계 ====================
+
+    /**
+     * 고객의 총 찜하기 개수
+     */
+    long countByCustomerId(String customerId);
+
+    /**
+     * 고객의 타입별 찜하기 개수
+     */
+    long countByCustomerIdAndType(String customerId, FavoriteType type);
+
+    /**
+     * 레스토랑의 총 찜하기 개수
+     */
+    long countByRestaurantId(String restaurantId);
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/entity/FavoriteEntity.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/entity/FavoriteEntity.java
@@ -1,0 +1,128 @@
+// FavoriteEntity.java
+package xyz.sparta_project.manjok.domain.favorites.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xyz.sparta_project.manjok.global.common.dto.BaseEntity;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 찜하기 JPA Entity
+ * - BaseEntity를 상속받아 ID와 createdAt 자동 관리
+ */
+@Entity
+@Table(
+        name = "p_favorite",
+        indexes = {
+                @Index(name = "idx_favorite_customer_id", columnList = "customer_id"),
+                @Index(name = "idx_favorite_customer_type", columnList = "customer_id, type"),
+                @Index(name = "idx_favorite_restaurant_id", columnList = "restaurant_id"),
+                @Index(name = "idx_favorite_customer_restaurant", columnList = "customer_id, restaurant_id"),
+                @Index(name = "idx_favorite_customer_restaurant_menu", columnList = "customer_id, restaurant_id, menu_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class FavoriteEntity extends BaseEntity {
+
+    @Column(name = "customer_id", nullable = false, length = 36)
+    private String customerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private FavoriteType type;
+
+    @Column(name = "restaurant_id", nullable = false, length = 36)
+    private String restaurantId;
+
+    @Column(name = "menu_id", length = 36)
+    private String menuId;
+
+    @Column(name = "created_by", length = 36)
+    private String createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", length = 36)
+    private String updatedBy;
+
+    // ==================== 도메인 ↔ 엔티티 변환 ====================
+
+    /**
+     * 도메인 모델을 엔티티로 변환
+     */
+    public static FavoriteEntity fromDomain(Favorite domain) {
+        if (domain == null) {
+            return null;
+        }
+
+        FavoriteEntity entity = FavoriteEntity.builder()
+                .customerId(domain.getCustomerId())
+                .type(domain.getType())
+                .restaurantId(domain.getRestaurantId())
+                .menuId(domain.getMenuId())
+                .createdBy(domain.getCreatedBy())
+                .updatedAt(domain.getUpdatedAt())
+                .updatedBy(domain.getUpdatedBy())
+                .build();
+
+        // ID와 createdAt 설정 (도메인에서 이미 있는 경우)
+        if (domain.getId() != null) {
+            entity.setIdFromDomain(domain.getId());
+        }
+        if (domain.getCreatedAt() != null) {
+            entity.setCreatedAtFromDomain(domain.getCreatedAt());
+        }
+
+        return entity;
+    }
+
+    /**
+     * 엔티티를 도메인 모델로 변환
+     */
+    public Favorite toDomain() {
+        return Favorite.builder()
+                .id(this.getId())
+                .createdAt(this.getCreatedAt())
+                .customerId(this.customerId)
+                .type(this.type)
+                .restaurantId(this.restaurantId)
+                .menuId(this.menuId)
+                .createdBy(this.createdBy)
+                .updatedAt(this.updatedAt)
+                .updatedBy(this.updatedBy)
+                .build();
+    }
+
+    // ==================== Helper Methods ====================
+
+    private void setIdFromDomain(String id) {
+        try {
+            java.lang.reflect.Field field = BaseEntity.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(this, id);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set ID from domain", e);
+        }
+    }
+
+    private void setCreatedAtFromDomain(LocalDateTime createdAt) {
+        try {
+            java.lang.reflect.Field field = BaseEntity.class.getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(this, createdAt);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set createdAt from domain", e);
+        }
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/jpa/FavoriteJpaRepository.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/jpa/FavoriteJpaRepository.java
@@ -1,0 +1,38 @@
+// FavoriteJpaRepository.java
+package xyz.sparta_project.manjok.domain.favorites.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.entity.FavoriteEntity;
+
+import java.util.List;
+
+public interface FavoriteJpaRepository extends JpaRepository<FavoriteEntity, String> {
+
+    List<FavoriteEntity> findByCustomerIdOrderByCreatedAtDesc(String customerId);
+
+    List<FavoriteEntity> findByCustomerIdAndTypeOrderByCreatedAtDesc(String customerId, FavoriteType type);
+
+    List<FavoriteEntity> findByRestaurantIdOrderByCreatedAtDesc(String restaurantId);
+
+    @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END " +
+            "FROM FavoriteEntity f " +
+            "WHERE f.customerId = :customerId " +
+            "AND f.type = :type " +
+            "AND f.restaurantId = :restaurantId " +
+            "AND (:menuId IS NULL OR f.menuId = :menuId)")
+    boolean existsByCustomerAndTarget(
+            @Param("customerId") String customerId,
+            @Param("type") FavoriteType type,
+            @Param("restaurantId") String restaurantId,
+            @Param("menuId") String menuId
+    );
+
+    long countByCustomerId(String customerId);
+
+    long countByCustomerIdAndType(String customerId, FavoriteType type);
+
+    long countByRestaurantId(String restaurantId);
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/repository/FavoriteRepositoryImpl.java
@@ -1,0 +1,225 @@
+// FavoriteRepositoryImpl.java
+package xyz.sparta_project.manjok.domain.favorites.infrastructure.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteErrorCode;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.domain.repository.FavoriteRepository;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.entity.FavoriteEntity;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.jpa.FavoriteJpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 찜하기 Repository 구현체
+ * - 도메인 리포지토리 인터페이스 구현
+ * - 도메인 ↔ 엔티티 변환 처리
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteRepositoryImpl implements FavoriteRepository {
+
+    private final FavoriteJpaRepository jpaRepository;
+
+    // ==================== CREATE ====================
+
+    @Override
+    @Transactional
+    public Favorite save(Favorite favorite) {
+        try {
+            // 신규 생성만 처리 (ID가 없는 경우)
+            if (favorite.getId() != null && jpaRepository.existsById(favorite.getId())) {
+                throw new FavoriteException(
+                        FavoriteErrorCode.EVENT_PROCESSING_FAILED,
+                        "이미 존재하는 찜하기입니다."
+                );
+            }
+
+            // 도메인 → 엔티티 변환
+            FavoriteEntity entity = FavoriteEntity.fromDomain(favorite);
+
+            // 저장
+            FavoriteEntity savedEntity = jpaRepository.save(entity);
+
+            log.info("찜하기 생성 성공. ID: {}, CustomerId: {}, Type: {}",
+                    savedEntity.getId(), savedEntity.getCustomerId(), savedEntity.getType());
+
+            // 엔티티 → 도메인 변환하여 반환
+            return savedEntity.toDomain();
+
+        } catch (FavoriteException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("찜하기 생성 실패: {}", favorite.getCustomerId(), e);
+            throw new FavoriteException(
+                    FavoriteErrorCode.FAVORITE_SAVE_FAILED,
+                    "찜하기 생성 중 오류가 발생했습니다: " + e.getMessage(),
+                    e
+            );
+        }
+    }
+
+    // ==================== DELETE ====================
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        try {
+            if (!jpaRepository.existsById(id)) {
+                throw new FavoriteException(FavoriteErrorCode.FAVORITE_NOT_FOUND);
+            }
+
+            jpaRepository.deleteById(id);
+
+            log.info("찜하기 삭제 성공. ID: {}", id);
+
+        } catch (FavoriteException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("찜하기 삭제 실패: {}", id, e);
+            throw new FavoriteException(
+                    FavoriteErrorCode.FAVORITE_DELETE_FAILED,
+                    "찜하기 삭제 중 오류가 발생했습니다",
+                    e
+            );
+        }
+    }
+
+    // ==================== READ - 단건 조회 ====================
+
+    @Override
+    public Optional<Favorite> findById(String id) {
+        try {
+            return jpaRepository.findById(id)
+                    .map(FavoriteEntity::toDomain);
+        } catch (Exception e) {
+            log.error("찜하기 조회 실패: {}", id, e);
+            throw new FavoriteException(
+                    FavoriteErrorCode.EVENT_PROCESSING_FAILED,
+                    "찜하기 조회 중 오류가 발생했습니다",
+                    e
+            );
+        }
+    }
+
+    // ==================== READ - 목록 조회 ====================
+
+    @Override
+    public List<Favorite> findByCustomerId(String customerId) {
+        try {
+            return jpaRepository.findByCustomerIdOrderByCreatedAtDesc(customerId)
+                    .stream()
+                    .map(FavoriteEntity::toDomain)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("고객 ID로 찜하기 조회 실패: {}", customerId, e);
+            throw new FavoriteException(
+                    FavoriteErrorCode.EVENT_PROCESSING_FAILED,
+                    "찜하기 목록 조회 중 오류가 발생했습니다",
+                    e
+            );
+        }
+    }
+
+    @Override
+    public List<Favorite> findByCustomerIdAndType(String customerId, FavoriteType type) {
+        try {
+            return jpaRepository.findByCustomerIdAndTypeOrderByCreatedAtDesc(customerId, type)
+                    .stream()
+                    .map(FavoriteEntity::toDomain)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("고객 ID와 타입으로 찜하기 조회 실패: {}, {}", customerId, type, e);
+            throw new FavoriteException(
+                    FavoriteErrorCode.EVENT_PROCESSING_FAILED,
+                    "찜하기 목록 조회 중 오류가 발생했습니다",
+                    e
+            );
+        }
+    }
+
+    @Override
+    public List<Favorite> findByRestaurantId(String restaurantId) {
+        try {
+            return jpaRepository.findByRestaurantIdOrderByCreatedAtDesc(restaurantId)
+                    .stream()
+                    .map(FavoriteEntity::toDomain)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("레스토랑 ID로 찜하기 조회 실패: {}", restaurantId, e);
+            throw new FavoriteException(
+                    FavoriteErrorCode.EVENT_PROCESSING_FAILED,
+                    "찜하기 목록 조회 중 오류가 발생했습니다",
+                    e
+            );
+        }
+    }
+
+    // ==================== 존재 확인 ====================
+
+    @Override
+    public boolean existsById(String id) {
+        try {
+            return jpaRepository.existsById(id);
+        } catch (Exception e) {
+            log.error("찜하기 존재 여부 확인 실패: {}", id, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean existsByCustomerAndTarget(
+            String customerId,
+            FavoriteType type,
+            String restaurantId,
+            String menuId
+    ) {
+        try {
+            return jpaRepository.existsByCustomerAndTarget(customerId, type, restaurantId, menuId);
+        } catch (Exception e) {
+            log.error("찜하기 존재 여부 확인 실패: {}, {}, {}, {}", customerId, type, restaurantId, menuId, e);
+            return false;
+        }
+    }
+
+    // ==================== 통계 ====================
+
+    @Override
+    public long countByCustomerId(String customerId) {
+        try {
+            return jpaRepository.countByCustomerId(customerId);
+        } catch (Exception e) {
+            log.error("고객의 찜하기 개수 조회 실패: {}", customerId, e);
+            return 0;
+        }
+    }
+
+    @Override
+    public long countByCustomerIdAndType(String customerId, FavoriteType type) {
+        try {
+            return jpaRepository.countByCustomerIdAndType(customerId, type);
+        } catch (Exception e) {
+            log.error("고객의 타입별 찜하기 개수 조회 실패: {}, {}", customerId, type, e);
+            return 0;
+        }
+    }
+
+    @Override
+    public long countByRestaurantId(String restaurantId) {
+        try {
+            return jpaRepository.countByRestaurantId(restaurantId);
+        } catch (Exception e) {
+            log.error("레스토랑의 찜하기 개수 조회 실패: {}", restaurantId, e);
+            return 0;
+        }
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/FavoriteController.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/FavoriteController.java
@@ -1,0 +1,188 @@
+// FavoriteController.java
+package xyz.sparta_project.manjok.domain.favorites.presentation.rest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import xyz.sparta_project.manjok.domain.favorites.application.service.FavoriteCommandService;
+import xyz.sparta_project.manjok.domain.favorites.application.service.FavoriteQueryService;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto.FavoriteCheckResponse;
+import xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto.FavoriteCreateRequest;
+import xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto.FavoriteResponse;
+import xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto.FavoriteStatisticsResponse;
+import xyz.sparta_project.manjok.global.presentation.dto.ApiResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/favorites")
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteCommandService favoriteCommandService;
+    private final FavoriteQueryService favoriteQueryService;
+
+    /**
+     * 찜하기 추가
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<FavoriteResponse> createFavorite(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @Valid @RequestBody FavoriteCreateRequest request
+    ) {
+        log.info("찜하기 추가 요청 - CustomerId: {}, Type: {}, RestaurantId: {}, MenuId: {}",
+                customerId, request.getType(), request.getRestaurantId(), request.getMenuId());
+
+        Favorite favorite;
+
+        if (request.getType() == FavoriteType.RESTAURANT) {
+            favorite = favoriteCommandService.addRestaurantFavorite(
+                    customerId,
+                    request.getRestaurantId()
+            );
+        } else {
+            favorite = favoriteCommandService.addMenuFavorite(
+                    customerId,
+                    request.getRestaurantId(),
+                    request.getMenuId()
+            );
+        }
+
+        return ApiResponse.success(
+                FavoriteResponse.from(favorite),
+                "찜하기가 추가되었습니다."
+        );
+    }
+
+    /**
+     * 찜하기 삭제
+     */
+    @DeleteMapping("/{favoriteId}")
+    public ApiResponse<Void> deleteFavorite(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @PathVariable String favoriteId
+    ) {
+        log.info("찜하기 삭제 요청 - CustomerId: {}, FavoriteId: {}", customerId, favoriteId);
+
+        favoriteCommandService.removeFavorite(customerId, favoriteId);
+
+        return ApiResponse.success(null, "찜하기가 취소되었습니다.");
+    }
+
+    /**
+     * 내 찜하기 목록 조회 (전체)
+     */
+    @GetMapping
+    public ApiResponse<List<FavoriteResponse>> getMyFavorites(
+            @RequestHeader("X-Customer-Id") String customerId
+    ) {
+        log.info("내 찜하기 목록 조회 - CustomerId: {}", customerId);
+
+        List<Favorite> favorites = favoriteQueryService.getCustomerFavorites(customerId);
+        List<FavoriteResponse> response = favorites.stream()
+                .map(FavoriteResponse::from)
+                .collect(Collectors.toList());
+
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 내 찜하기 목록 조회 (타입별)
+     */
+    @GetMapping("/type/{type}")
+    public ApiResponse<List<FavoriteResponse>> getMyFavoritesByType(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @PathVariable FavoriteType type
+    ) {
+        log.info("내 찜하기 목록 조회 (타입별) - CustomerId: {}, Type: {}", customerId, type);
+
+        List<Favorite> favorites = favoriteQueryService.getCustomerFavoritesByType(customerId, type);
+        List<FavoriteResponse> response = favorites.stream()
+                .map(FavoriteResponse::from)
+                .collect(Collectors.toList());
+
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 찜하기 여부 확인 (레스토랑)
+     */
+    @GetMapping("/check/restaurant/{restaurantId}")
+    public ApiResponse<FavoriteCheckResponse> checkRestaurantFavorite(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @PathVariable String restaurantId
+    ) {
+        log.info("레스토랑 찜하기 여부 확인 - CustomerId: {}, RestaurantId: {}", customerId, restaurantId);
+
+        boolean isFavorite = favoriteQueryService.isRestaurantFavorite(customerId, restaurantId);
+
+        return ApiResponse.success(FavoriteCheckResponse.of(isFavorite));
+    }
+
+    /**
+     * 찜하기 여부 확인 (메뉴)
+     */
+    @GetMapping("/check/menu")
+    public ApiResponse<FavoriteCheckResponse> checkMenuFavorite(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @RequestParam String restaurantId,
+            @RequestParam String menuId
+    ) {
+        log.info("메뉴 찜하기 여부 확인 - CustomerId: {}, RestaurantId: {}, MenuId: {}",
+                customerId, restaurantId, menuId);
+
+        boolean isFavorite = favoriteQueryService.isMenuFavorite(customerId, restaurantId, menuId);
+
+        return ApiResponse.success(FavoriteCheckResponse.of(isFavorite));
+    }
+
+    /**
+     * 찜하기 상세 조회
+     */
+    @GetMapping("/{favoriteId}")
+    public ApiResponse<FavoriteResponse> getFavorite(
+            @PathVariable String favoriteId
+    ) {
+        log.info("찜하기 상세 조회 - FavoriteId: {}", favoriteId);
+
+        Favorite favorite = favoriteQueryService.getFavorite(favoriteId);
+
+        return ApiResponse.success(FavoriteResponse.from(favorite));
+    }
+
+    /**
+     * 내 찜하기 통계 조회
+     */
+    @GetMapping("/statistics")
+    public ApiResponse<FavoriteStatisticsResponse> getMyFavoriteStatistics(
+            @RequestHeader("X-Customer-Id") String customerId
+    ) {
+        log.info("내 찜하기 통계 조회 - CustomerId: {}", customerId);
+
+        FavoriteQueryService.FavoriteStatistics statistics =
+                favoriteQueryService.getCustomerFavoriteStatistics(customerId);
+
+        return ApiResponse.success(FavoriteStatisticsResponse.from(statistics));
+    }
+
+    /**
+     * 레스토랑의 찜하기 개수 조회
+     */
+    @GetMapping("/restaurant/{restaurantId}/count")
+    public ApiResponse<Long> getRestaurantFavoriteCount(
+            @PathVariable String restaurantId
+    ) {
+        log.info("레스토랑 찜하기 개수 조회 - RestaurantId: {}", restaurantId);
+
+        long count = favoriteQueryService.getRestaurantFavoriteCount(restaurantId);
+
+        return ApiResponse.success(count);
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteCheckResponse.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteCheckResponse.java
@@ -1,0 +1,24 @@
+// FavoriteCheckResponse.java
+package xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FavoriteCheckResponse {
+
+    private boolean isFavorite;
+
+    /**
+     * boolean 값을 DTO로 변환
+     */
+    public static FavoriteCheckResponse of(boolean isFavorite) {
+        return FavoriteCheckResponse.builder()
+                .isFavorite(isFavorite)
+                .build();
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteCreateRequest.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteCreateRequest.java
@@ -1,0 +1,25 @@
+// FavoriteCreateRequest.java
+package xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FavoriteCreateRequest {
+
+    @NotNull(message = "찜하기 타입은 필수입니다.")
+    private FavoriteType type;
+
+    @NotBlank(message = "레스토랑 ID는 필수입니다.")
+    private String restaurantId;
+
+    private String menuId; // 메뉴 타입일 때만 필수
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteResponse.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteResponse.java
@@ -1,0 +1,38 @@
+// FavoriteResponse.java
+package xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FavoriteResponse {
+
+    private String id;
+    private String customerId;
+    private FavoriteType type;
+    private String restaurantId;
+    private String menuId;
+    private LocalDateTime createdAt;
+
+    /**
+     * 도메인 모델을 DTO로 변환
+     */
+    public static FavoriteResponse from(Favorite favorite) {
+        return FavoriteResponse.builder()
+                .id(favorite.getId())
+                .customerId(favorite.getCustomerId())
+                .type(favorite.getType())
+                .restaurantId(favorite.getRestaurantId())
+                .menuId(favorite.getMenuId())
+                .createdAt(favorite.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteStatisticsResponse.java
+++ b/src/main/java/xyz/sparta_project/manjok/domain/favorites/presentation/rest/dto/FavoriteStatisticsResponse.java
@@ -1,0 +1,29 @@
+// FavoriteStatisticsResponse.java
+package xyz.sparta_project.manjok.domain.favorites.presentation.rest.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import xyz.sparta_project.manjok.domain.favorites.application.service.FavoriteQueryService.FavoriteStatistics;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FavoriteStatisticsResponse {
+
+    private long totalCount;
+    private long restaurantCount;
+    private long menuCount;
+
+    /**
+     * 통계 객체를 DTO로 변환
+     */
+    public static FavoriteStatisticsResponse from(FavoriteStatistics statistics) {
+        return FavoriteStatisticsResponse.builder()
+                .totalCount(statistics.getTotalCount())
+                .restaurantCount(statistics.getRestaurantCount())
+                .menuCount(statistics.getMenuCount())
+                .build();
+    }
+}

--- a/src/test/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteCommandServiceTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteCommandServiceTest.java
@@ -1,0 +1,117 @@
+package xyz.sparta_project.manjok.domain.favorites.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.domain.repository.FavoriteRepository;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.repository.FavoriteRepositoryImpl;
+import xyz.sparta_project.manjok.domain.restaurant.domain.event.WishlistChangedEvent;
+import xyz.sparta_project.manjok.global.infrastructure.event.infrastructure.Events;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DataJpaTest
+@Import({
+        FavoriteRepositoryImpl.class,
+        FavoriteCommandService.class
+})
+@DisplayName("FavoriteCommandService 테스트")
+class FavoriteCommandServiceTest {
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Autowired
+    private FavoriteCommandService commandService;
+
+    @BeforeEach
+    void setup() {
+        // userA 기본 데이터 준비
+        favoriteRepository.save(Favorite.createRestaurantFavorite("userA", "rest1", "userA"));
+        favoriteRepository.save(Favorite.createMenuFavorite("userA", "rest1", "menu1", "userA"));
+    }
+
+    @Test
+    @DisplayName("레스토랑 찜하기 추가 시 DB에 저장되고 이벤트가 발행된다")
+    void addRestaurantFavorite() {
+        try (MockedStatic<Events> eventsMock = mockStatic(Events.class)) {
+
+            // when
+            Favorite result = commandService.addRestaurantFavorite("userB", "rest2");
+
+            // then: DB 검증
+            assertThat(result.getCustomerId()).isEqualTo("userB");
+            assertThat(result.getRestaurantId()).isEqualTo("rest2");
+            assertThat(result.getType()).isEqualTo(FavoriteType.RESTAURANT);
+
+            // then: 이벤트 발행 검증
+            eventsMock.verify(() -> Events.raise(any(WishlistChangedEvent.class)), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("이미 찜한 레스토랑이면 예외가 발생한다")
+    void addRestaurantFavorite_Duplicate() {
+        // userA 이미 rest1을 찜함
+        assertThatThrownBy(() -> commandService.addRestaurantFavorite("userA", "rest1"))
+                .isInstanceOf(FavoriteException.class);
+    }
+
+    @Test
+    @DisplayName("메뉴 찜하기 추가 시 DB에 저장되고 이벤트가 발행된다")
+    void addMenuFavorite() {
+        try (MockedStatic<Events> eventsMock = mockStatic(Events.class)) {
+
+            // when
+            Favorite result = commandService.addMenuFavorite("userB", "rest3", "menuX");
+
+            // then: DB 검증
+            assertThat(result.getCustomerId()).isEqualTo("userB");
+            assertThat(result.getRestaurantId()).isEqualTo("rest3");
+            assertThat(result.getMenuId()).isEqualTo("menuX");
+            assertThat(result.getType()).isEqualTo(FavoriteType.MENU);
+
+            // then: 이벤트 발행 검증
+            eventsMock.verify(() -> Events.raise(any(WishlistChangedEvent.class)), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("찜하기 삭제 시 DB에서 삭제되고 이벤트가 발행된다")
+    void removeFavorite() {
+        Favorite favorite = favoriteRepository.save(
+                Favorite.createRestaurantFavorite("userX", "rest9", "userX")
+        );
+
+        try (MockedStatic<Events> eventsMock = mockStatic(Events.class)) {
+
+            // when
+            commandService.removeFavorite("userX", favorite.getId());
+
+            // then: DB에서 사라져야 함
+            assertThat(favoriteRepository.findById(favorite.getId())).isEmpty();
+
+            // then: 이벤트 발행 검증
+            eventsMock.verify(() -> Events.raise(any(WishlistChangedEvent.class)), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("본인이 아닌 찜을 삭제하려고 하면 예외가 발생한다")
+    void removeFavorite_Forbidden() {
+        Favorite favorite = favoriteRepository.save(
+                Favorite.createRestaurantFavorite("ownerUser", "rest100", "ownerUser")
+        );
+
+        assertThatThrownBy(() -> commandService.removeFavorite("otherUser", favorite.getId()))
+                .isInstanceOf(FavoriteException.class);
+    }
+}

--- a/src/test/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteQueryServiceTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/domain/favorites/application/service/FavoriteQueryServiceTest.java
@@ -1,0 +1,122 @@
+package xyz.sparta_project.manjok.domain.favorites.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.domain.repository.FavoriteRepository;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.repository.FavoriteRepositoryImpl;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import({
+        FavoriteRepositoryImpl.class,
+        FavoriteQueryService.class
+})
+@DisplayName("FavoriteQueryService 테스트")
+class FavoriteQueryServiceTest {
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Autowired
+    private FavoriteQueryService queryService;
+
+    private Favorite createRestaurant(String customerId, String restaurantId) {
+        return Favorite.createRestaurantFavorite(customerId, restaurantId, customerId);
+    }
+
+    private Favorite createMenu(String customerId, String restaurantId, String menuId) {
+        return Favorite.createMenuFavorite(customerId, restaurantId, menuId, customerId);
+    }
+
+    @BeforeEach
+    void setup() {
+        // userA
+        favoriteRepository.save(createRestaurant("userA", "rest1"));
+        favoriteRepository.save(createMenu("userA", "rest1", "menu1"));
+
+        // userB
+        favoriteRepository.save(createRestaurant("userB", "rest2"));
+        favoriteRepository.save(createMenu("userB", "rest2", "menu2"));
+    }
+
+    @Test
+    @DisplayName("favoriteId 로 찜 상세를 조회할 수 있다")
+    void getFavorite() {
+        // given
+        Favorite saved = favoriteRepository.save(createRestaurant("userX", "restX"));
+
+        // when
+        Favorite result = queryService.getFavorite(saved.getId());
+
+        // then
+        assertThat(result.getCustomerId()).isEqualTo("userX");
+        assertThat(result.getRestaurantId()).isEqualTo("restX");
+        assertThat(result.getType()).isEqualTo(FavoriteType.RESTAURANT);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 FavoriteId 조회 시 예외가 발생한다")
+    void getFavorite_NotFound() {
+        assertThatThrownBy(() -> queryService.getFavorite("not_exist"))
+                .isInstanceOf(FavoriteException.class);
+    }
+
+    @Test
+    @DisplayName("고객의 전체 찜 목록을 조회할 수 있다")
+    void getCustomerFavorites() {
+        List<Favorite> list = queryService.getCustomerFavorites("userA");
+        assertThat(list).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("고객의 레스토랑 찜 목록만 조회할 수 있다")
+    void getCustomerRestaurantFavorites() {
+        List<Favorite> list = queryService.getCustomerRestaurantFavorites("userA");
+
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).getType()).isEqualTo(FavoriteType.RESTAURANT);
+    }
+
+    @Test
+    @DisplayName("고객의 메뉴 찜 목록만 조회할 수 있다")
+    void getCustomerMenuFavorites() {
+        List<Favorite> list = queryService.getCustomerMenuFavorites("userA");
+
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).getType()).isEqualTo(FavoriteType.MENU);
+    }
+
+    @Test
+    @DisplayName("특정 대상에 대해 찜 여부를 확인할 수 있다")
+    void isFavorite() {
+        boolean result = queryService.isFavorite("userA", FavoriteType.MENU, "rest1", "menu1");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("고객의 찜하기 통계를 조회할 수 있다")
+    void getCustomerFavoriteStatistics() {
+        FavoriteQueryService.FavoriteStatistics stats = queryService.getCustomerFavoriteStatistics("userA");
+
+        assertThat(stats.getTotalCount()).isEqualTo(2);
+        assertThat(stats.getRestaurantCount()).isEqualTo(1);
+        assertThat(stats.getMenuCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("레스토랑의 찜 개수를 조회할 수 있다")
+    void getRestaurantFavoriteCount() {
+        long count = queryService.getRestaurantFavoriteCount("rest1");
+        assertThat(count).isEqualTo(2); // REST + MENU
+    }
+}

--- a/src/test/java/xyz/sparta_project/manjok/domain/favorites/domain/model/FavoriteTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/domain/favorites/domain/model/FavoriteTest.java
@@ -1,0 +1,132 @@
+package xyz.sparta_project.manjok.domain.favorites.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteErrorCode;
+import xyz.sparta_project.manjok.domain.favorites.domain.exception.FavoriteException;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Favorite 도메인 모델 테스트")
+class FavoriteTest {
+
+    @Test
+    @DisplayName("레스토랑 찜하기를 생성할 수 있다")
+    void createRestaurantFavorite() {
+        // given
+        String customerId = "user123";
+        String restaurantId = "rest001";
+        String createdBy = "user123";
+
+        // when
+        Favorite favorite = Favorite.createRestaurantFavorite(customerId, restaurantId, createdBy);
+
+        // then
+        assertThat(favorite.getCustomerId()).isEqualTo(customerId);
+        assertThat(favorite.getType()).isEqualTo(FavoriteType.RESTAURANT);
+        assertThat(favorite.getRestaurantId()).isEqualTo(restaurantId);
+        assertThat(favorite.getMenuId()).isNull();
+        assertThat(favorite.isRestaurantFavorite()).isTrue();
+        assertThat(favorite.isMenuFavorite()).isFalse();
+    }
+
+    @Test
+    @DisplayName("메뉴 찜하기를 생성할 수 있다")
+    void createMenuFavorite() {
+        // given
+        String customerId = "user123";
+        String restaurantId = "rest001";
+        String menuId = "menu001";
+        String createdBy = "user123";
+
+        // when
+        Favorite favorite = Favorite.createMenuFavorite(customerId, restaurantId, menuId, createdBy);
+
+        // then
+        assertThat(favorite.getCustomerId()).isEqualTo(customerId);
+        assertThat(favorite.getType()).isEqualTo(FavoriteType.MENU);
+        assertThat(favorite.getRestaurantId()).isEqualTo(restaurantId);
+        assertThat(favorite.getMenuId()).isEqualTo(menuId);
+        assertThat(favorite.isMenuFavorite()).isTrue();
+        assertThat(favorite.isRestaurantFavorite()).isFalse();
+    }
+
+    @Test
+    @DisplayName("레스토랑 찜하기 생성 시 menuId 가 존재하면 예외가 발생한다")
+    void createRestaurantFavorite_InvalidMenuId() {
+        // given
+        Favorite favorite = Favorite.builder()
+                .customerId("user123")
+                .type(FavoriteType.RESTAURANT)
+                .restaurantId("rest001")
+                .menuId("menu001") // 잘못된 입력
+                .createdBy("user123")
+                .build();
+
+        // when & then
+        assertThatThrownBy(favorite::validate)
+                .isInstanceOf(FavoriteException.class)
+                .extracting("errorCode")
+                .isEqualTo(FavoriteErrorCode.MENU_ID_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("메뉴 찜하기 생성 시 menuId 가 없으면 예외가 발생한다")
+    void createMenuFavorite_MenuIdMissing() {
+        // given
+        Favorite favorite = Favorite.builder()
+                .customerId("user123")
+                .restaurantId("rest001")
+                .type(FavoriteType.MENU)
+                .menuId(null)
+                .createdBy("user123")
+                .build();
+
+        // when & then
+        assertThatThrownBy(favorite::validate)
+                .isInstanceOf(FavoriteException.class)
+                .extracting("errorCode")
+                .isEqualTo(FavoriteErrorCode.MENU_ID_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("소유자 검증에 실패하면 예외가 발생한다")
+    void validateOwner() {
+        // given
+        Favorite favorite = Favorite.createRestaurantFavorite("ownerA", "rest001", "ownerA");
+
+        // when & then
+        assertThatThrownBy(() -> favorite.validateOwner("otherUser"))
+                .isInstanceOf(FavoriteException.class)
+                .extracting("errorCode")
+                .isEqualTo(FavoriteErrorCode.FORBIDDEN_FAVORITE_ACCESS);
+    }
+
+    @Test
+    @DisplayName("동일한 찜하기 판단이 올바르게 동작한다")
+    void isSameFavorite() {
+        // given
+        Favorite f1 = Favorite.createMenuFavorite("user123", "rest001", "menu001", "user123");
+        Favorite f2 = Favorite.createMenuFavorite("user123", "rest001", "menu001", "user123");
+
+        // when
+        boolean result = f1.isSameFavorite(f2);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("레스토랑 찜하기와 메뉴 찜하기는 동일하지 않다")
+    void isSameFavorite_DifferentType() {
+        // given
+        Favorite f1 = Favorite.createRestaurantFavorite("user123", "rest001", "user123");
+        Favorite f2 = Favorite.createMenuFavorite("user123", "rest001", "menu001", "user123");
+
+        // when
+        boolean result = f1.isSameFavorite(f2);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/xyz/sparta_project/manjok/domain/favorites/domain/model/FavoriteTypeTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/domain/favorites/domain/model/FavoriteTypeTest.java
@@ -1,0 +1,64 @@
+package xyz.sparta_project.manjok.domain.favorites.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("FavoriteType 이넘 테스트")
+class FavoriteTypeTest {
+
+    @Test
+    @DisplayName("대소문자를 구분하지 않고 문자열로 FavoriteType 을 찾을 수 있다")
+    void fromString_Valid() {
+        // given
+        String value1 = "RESTAURANT";
+        String value2 = "restaurant";
+        String value3 = "Restaurant";
+
+        // when & then
+        assertThat(FavoriteType.fromString(value1)).isEqualTo(FavoriteType.RESTAURANT);
+        assertThat(FavoriteType.fromString(value2)).isEqualTo(FavoriteType.RESTAURANT);
+        assertThat(FavoriteType.fromString(value3)).isEqualTo(FavoriteType.RESTAURANT);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 문자열을 입력하면 예외가 발생한다")
+    void fromString_Invalid() {
+        // given
+        String invalid = "INVALID";
+
+        // when & then
+        assertThatThrownBy(() -> FavoriteType.fromString(invalid))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid FavoriteType");
+    }
+
+    @Test
+    @DisplayName("RESTAURANT 타입은 isRestaurant() 가 true 이다")
+    void isRestaurant() {
+        // given
+        FavoriteType type = FavoriteType.RESTAURANT;
+
+        // when
+        boolean result = type.isRestaurant();
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(type.isMenu()).isFalse();
+    }
+
+    @Test
+    @DisplayName("MENU 타입은 isMenu() 가 true 이다")
+    void isMenu() {
+        // given
+        FavoriteType type = FavoriteType.MENU;
+
+        // when
+        boolean result = type.isMenu();
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(type.isRestaurant()).isFalse();
+    }
+}

--- a/src/test/java/xyz/sparta_project/manjok/domain/favorites/domain/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/domain/favorites/domain/repository/FavoriteRepositoryTest.java
@@ -1,0 +1,148 @@
+package xyz.sparta_project.manjok.domain.favorites.domain.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.repository.FavoriteRepositoryImpl;
+import xyz.sparta_project.manjok.domain.favorites.infrastructure.jpa.FavoriteJpaRepository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@DataJpaTest
+@Import(FavoriteRepositoryImpl.class) // RepositoryImpl 주입
+@DisplayName("FavoriteRepository 테스트")
+class FavoriteRepositoryTest {
+
+    @Autowired
+    private FavoriteRepositoryImpl repository;
+
+    @Autowired
+    private FavoriteJpaRepository jpaRepository;
+
+    private Favorite createRestaurantFavorite(String customerId, String restaurantId) {
+        return Favorite.createRestaurantFavorite(customerId, restaurantId, customerId);
+    }
+
+    private Favorite createMenuFavorite(String customerId, String restaurantId, String menuId) {
+        return Favorite.createMenuFavorite(customerId, restaurantId, menuId, customerId);
+    }
+
+    @Test
+    @DisplayName("찜하기를 저장할 수 있다")
+    void saveFavorite() {
+        // given
+        Favorite favorite = createRestaurantFavorite("user1", "rest1");
+
+        // when
+        Favorite saved = repository.save(favorite);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCustomerId()).isEqualTo("user1");
+        assertThat(saved.getRestaurantId()).isEqualTo("rest1");
+        assertThat(saved.getType()).isEqualTo(FavoriteType.RESTAURANT);
+        assertThat(repository.existsById(saved.getId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("ID로 찜하기를 조회할 수 있다")
+    void findById() {
+        // given
+        Favorite favorite = repository.save(createMenuFavorite("user1", "rest1", "menu1"));
+
+        // when
+        Optional<Favorite> result = repository.findById(favorite.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getMenuId()).isEqualTo("menu1");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 조회하면 Optional.empty() 가 반환된다")
+    void findById_NotFound() {
+        // when
+        Optional<Favorite> result = repository.findById("not-exist");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("고객 ID로 찜하기 목록을 조회할 수 있다")
+    void findByCustomerId() {
+        // given
+        repository.save(createRestaurantFavorite("userX", "rest1"));
+        repository.save(createMenuFavorite("userX", "rest1", "menu1"));
+
+        // when
+        List<Favorite> list = repository.findByCustomerId("userX");
+
+        // then
+        assertThat(list).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("고객 ID와 타입으로 찜하기 목록을 조회할 수 있다")
+    void findByCustomerIdAndType() {
+        // given
+        repository.save(createRestaurantFavorite("user1", "restA"));
+        repository.save(createMenuFavorite("user1", "restA", "menuA"));
+
+        // when
+        List<Favorite> restaurantFavorites = repository.findByCustomerIdAndType("user1", FavoriteType.RESTAURANT);
+        List<Favorite> menuFavorites = repository.findByCustomerIdAndType("user1", FavoriteType.MENU);
+
+        // then
+        assertThat(restaurantFavorites).hasSize(1);
+        assertThat(menuFavorites).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("찜하기 삭제 시 실제로 삭제된다")
+    void deleteFavorite() {
+        // given
+        Favorite favorite = repository.save(createRestaurantFavorite("user1", "rest1"));
+
+        // when
+        repository.delete(favorite.getId());
+
+        // then
+        assertThat(repository.existsById(favorite.getId())).isFalse();
+        assertThat(repository.findById(favorite.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특정 대상에 대해 찜하기가 존재하는지 확인할 수 있다")
+    void existsByCustomerAndTarget() {
+        // given
+        repository.save(createMenuFavorite("user1", "rest1", "menu1"));
+
+        // when
+        boolean exists = repository.existsByCustomerAndTarget("user1", FavoriteType.MENU, "rest1", "menu1");
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("고객의 총 찜하기 개수를 조회할 수 있다")
+    void countByCustomerId() {
+        // given
+        repository.save(createRestaurantFavorite("user1", "rest1"));
+        repository.save(createMenuFavorite("user1", "rest1", "menu1"));
+
+        // when
+        long count = repository.countByCustomerId("user1");
+
+        // then
+        assertThat(count).isEqualTo(2);
+    }
+}

--- a/src/test/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/entity/FavoriteEntityTest.java
+++ b/src/test/java/xyz/sparta_project/manjok/domain/favorites/infrastructure/entity/FavoriteEntityTest.java
@@ -1,0 +1,94 @@
+package xyz.sparta_project.manjok.domain.favorites.infrastructure.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.Favorite;
+import xyz.sparta_project.manjok.domain.favorites.domain.model.FavoriteType;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("FavoriteEntity 테스트")
+class FavoriteEntityTest {
+
+    @Test
+    @DisplayName("도메인 모델을 엔티티로 변환할 수 있다")
+    void fromDomain() {
+        // given
+        Favorite domain = Favorite.builder()
+                .id("FAV123")
+                .createdAt(LocalDateTime.of(2024, 1, 1, 10, 0))
+                .customerId("USER123")
+                .type(FavoriteType.MENU)
+                .restaurantId("REST001")
+                .menuId("MENU001")
+                .createdBy("USER123")
+                .updatedAt(LocalDateTime.of(2024, 1, 2, 12, 0))
+                .updatedBy("USER321")
+                .build();
+
+        // when
+        FavoriteEntity entity = FavoriteEntity.fromDomain(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo("FAV123");
+        assertThat(entity.getCreatedAt()).isEqualTo(LocalDateTime.of(2024, 1, 1, 10, 0));
+        assertThat(entity.getCustomerId()).isEqualTo("USER123");
+        assertThat(entity.getType()).isEqualTo(FavoriteType.MENU);
+        assertThat(entity.getRestaurantId()).isEqualTo("REST001");
+        assertThat(entity.getMenuId()).isEqualTo("MENU001");
+        assertThat(entity.getCreatedBy()).isEqualTo("USER123");
+        assertThat(entity.getUpdatedAt()).isEqualTo(LocalDateTime.of(2024, 1, 2, 12, 0));
+        assertThat(entity.getUpdatedBy()).isEqualTo("USER321");
+    }
+
+    @Test
+    @DisplayName("엔티티를 도메인 모델로 변환할 수 있다")
+    void toDomain() {
+        // given - 도메인 → 엔티티 변환 (ID, createdAt 자동 반영)
+        Favorite original = Favorite.builder()
+                .id("FAV456")
+                .createdAt(LocalDateTime.of(2024, 1, 1, 9, 30))
+                .customerId("USER123")
+                .type(FavoriteType.RESTAURANT)
+                .restaurantId("REST001")
+                .menuId(null)
+                .createdBy("USER123")
+                .updatedAt(LocalDateTime.of(2024, 1, 3, 15, 0))
+                .updatedBy("USER123")
+                .build();
+
+        FavoriteEntity entity = FavoriteEntity.fromDomain(original);
+
+        // when
+        Favorite converted = entity.toDomain();
+
+        // then
+        assertThat(converted).usingRecursiveComparison().isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("도메인 → 엔티티 → 도메인 변환 시 데이터가 변형되지 않는다 (왕복 테스트)")
+    void domainToEntityToDomain() {
+        // given
+        Favorite original = Favorite.builder()
+                .id("FAV999")
+                .createdAt(LocalDateTime.of(2024, 1, 1, 8, 0))
+                .customerId("USER001")
+                .type(FavoriteType.MENU)
+                .restaurantId("REST100")
+                .menuId("MENU100")
+                .createdBy("USER001")
+                .updatedAt(LocalDateTime.of(2024, 1, 5, 11, 45))
+                .updatedBy("USER900")
+                .build();
+
+        // when
+        FavoriteEntity entity = FavoriteEntity.fromDomain(original);
+        Favorite result = entity.toDomain();
+
+        // then
+        assertThat(result).usingRecursiveComparison().isEqualTo(original);
+    }
+}


### PR DESCRIPTION
# 1. 요약 (Summary)

즐겨찾기(Favorites) 기능을 구현하여 사용자가 메뉴 또는 레스토랑을 찜하고, 이를 조회 및 해제할 수 있도록 했습니다. 또한 사용자 개인 기준의 즐겨찾기 조회 기능과 관리자용 통계 조회 API를 제공합니다.

본 구현을 통해 고객 경험 개선과 함께 메뉴/레스토랑 인기 데이터 기반의 추천 및 통계 분석 기능 확장의 기반을 마련했습니다.

# 2. 작업 내용 (Details)

## 2.1 도메인 모델 구현

| 모델       | 책임         | 설명                            |
| -------- | ---------- | ----------------------------- |
| Favorite | 즐겨찾기 관계 표현 | 사용자와 메뉴/레스토랑 간의 즐겨찾기 연결 정보 저장 |

### 주요 필드

* id: 즐겨찾기 식별자 (UUID)
* customerId: 사용자 ID
* type: FavoriteType (MENU, RESTAURANT)
* restaurantId (nullable): 레스토랑 대상일 경우 참조
* menuId (nullable): 메뉴 대상일 경우 참조
* createdAt: 생성 일시

### FavoriteType Enum

* RESTAURANT
* MENU

## 2.2 Repository 계층

* `FavoriteRepository` (도메인 관점 인터페이스)
* `FavoriteRepositoryImpl` (QueryDSL 기반 구현)
* `FavoriteJpaRepository` (Spring Data JPA 기반 기본 CRUD)

## 2.3 Application Layer

| 서비스                    | 역할                          |
| ---------------------- | --------------------------- |
| FavoriteCommandService | 즐겨찾기 생성 및 제거 처리 (이벤트 발행 포함) |
| FavoriteQueryService   | 즐겨찾기 조회 및 통계 조회 처리          |

### 핵심 메서드

* `addRestaurantFavorite(customerId, restaurantId)`
* `addMenuFavorite(customerId, restaurantId, menuId)`
* `removeFavorite(customerId, favoriteId)`
* `getCustomerFavorites(customerId)`
* `getCustomerFavoriteStatistics(customerId)`
* `getRestaurantFavoriteCount(restaurantId)`

## 2.4 Presentation Layer (API)

### 사용자용 API

| Method | Path                                    | 설명              |
| ------ | --------------------------------------- | --------------- |
| POST   | /api/v1/favorites                       | 메뉴/레스토랑 즐겨찾기 등록 |
| DELETE | /api/v1/favorites/{favoriteId}          | 즐겨찾기 해제         |
| GET    | /api/v1/favorites                       | 내 즐겨찾기 전체 조회    |
| GET    | /api/v1/favorites/type/{type}           | 타입별 즐겨찾기 조회     |
| GET    | /api/v1/favorites/check/restaurant/{id} | 레스토랑 즐겨찾기 여부 확인 |
| GET    | /api/v1/favorites/check/menu            | 메뉴 즐겨찾기 여부 확인   |
| GET    | /api/v1/favorites/statistics            | 내 즐겨찾기 통계 조회    |

### 관리자용 API

| Method | Path                                    | 설명                 |
| ------ | --------------------------------------- | ------------------ |
| GET    | /api/v1/favorites/restaurant/{id}/count | 특정 레스토랑 즐겨찾기 개수 조회 |

## 2.5 이벤트 기반 통계 처리

* WishlistChangedEvent 발행
* 레스토랑/메뉴 찜 개수 증가/감소 처리와 연계 가능한 구조 확보

# 3. 테스트 방법 (Testing)

## 3.1 Command Service 테스트

* 중복 즐겨찾기 요청 시 예외 발생 검증
* 정상 즐겨찾기 생성 후 이벤트 발행 검증
* 즐겨찾기 삭제 시 DB 삭제 및 이벤트 발행 검증

## 3.2 Query Service 테스트

* 사용자별 즐겨찾기 목록 정확히 반환되는지 확인
* 타입별 조회 필터 검증
* 즐겨찾기 통계 반환 값 검증

# 4. 변경 유형 (Change Type)

* NEW FEATURE: 즐겨찾기(Favorites) 기능 신규 구현
* TEST: Command/Query 서비스 단위 테스트 추가

# 5. 추가 고려 사항

* 추천 알고리즘과 통계 대시보드와 연계 가능
* 향후 Redis 캐싱 및 인기순 정렬 API 확장 예정
